### PR TITLE
Add options section for simple request matcher.

### DIFF
--- a/src/mockttp.ts
+++ b/src/mockttp.ts
@@ -4,7 +4,7 @@
 
 import MockRuleBuilder from "./rules/mock-rule-builder";
 import { ProxyConfig, MockedEndpoint, Method, OngoingRequest } from "./types";
-import { MockRuleData } from "./rules/mock-rule-types";
+import { MockRuleData, MockRuleCtx } from "./rules/mock-rule-types";
 import { CAOptions } from './util/tls';
 
 /**
@@ -78,23 +78,23 @@ export interface Mockttp {
     /**
      * Get a builder for a mock rule that will match GET requests for the given path.
      */
-    get(url: string): MockRuleBuilder;
+    get(url: string, ctx?: MockRuleCtx): MockRuleBuilder;
     /**
      * Get a builder for a mock rule that will match POST requests for the given path.
      */
-    post(url: string): MockRuleBuilder;
+    post(url: string, ctx?: MockRuleCtx): MockRuleBuilder;
     /**
      * Get a builder for a mock rule that will match PUT requests for the given path.
      */
-    put(url: string): MockRuleBuilder;
+    put(url: string, ctx?: MockRuleCtx): MockRuleBuilder;
     /**
      * Get a builder for a mock rule that will match DELETE requests for the given path.
      */
-    delete(url: string): MockRuleBuilder;
+    delete(url: string, ctx?: MockRuleCtx): MockRuleBuilder;
     /**
      * Get a builder for a mock rule that will match PATCH requests for the given path.
      */
-    patch(url: string): MockRuleBuilder;
+    patch(url: string, ctx?: MockRuleCtx): MockRuleBuilder;
     /**
      * Get a builder for a mock rule that will match OPTIONS requests for the given path.
      * 
@@ -108,7 +108,7 @@ export interface Mockttp {
      * but if you're testing in a browser you will need to ensure you mock all OPTIONS
      * requests appropriately so that the browser allows your other requests to be sent.
      */
-    options(url: string): MockRuleBuilder;
+    options(url: string, ctx?: MockRuleCtx): MockRuleBuilder;
 
     /**
      * Subscribe to hear about request details as they're received.
@@ -160,27 +160,27 @@ export abstract class AbstractMockttp {
         return new MockRuleBuilder(this.addRule);
     }
 
-    get(url: string): MockRuleBuilder {
-        return new MockRuleBuilder(Method.GET, url, this.addRule);
+    get(url: string, ctx?: MockRuleCtx): MockRuleBuilder {
+        return new MockRuleBuilder(Method.GET, url, this.addRule, ctx);
     }
 
-    post(url: string): MockRuleBuilder {
-        return new MockRuleBuilder(Method.POST, url, this.addRule);
+    post(url: string, ctx?: MockRuleCtx): MockRuleBuilder {
+        return new MockRuleBuilder(Method.POST, url, this.addRule, ctx);
     }
 
-    put(url: string): MockRuleBuilder {
-        return new MockRuleBuilder(Method.PUT, url, this.addRule);
+    put(url: string, ctx?: MockRuleCtx): MockRuleBuilder {
+        return new MockRuleBuilder(Method.PUT, url, this.addRule, ctx);
     }
     
-    delete(url: string): MockRuleBuilder {
-        return new MockRuleBuilder(Method.DELETE, url, this.addRule);
+    delete(url: string, ctx?: MockRuleCtx): MockRuleBuilder {
+        return new MockRuleBuilder(Method.DELETE, url, this.addRule, ctx);
     }
 
-    patch(url: string): MockRuleBuilder {
-        return new MockRuleBuilder(Method.PATCH, url, this.addRule);
+    patch(url: string, ctx?: MockRuleCtx): MockRuleBuilder {
+        return new MockRuleBuilder(Method.PATCH, url, this.addRule, ctx);
     }
 
-    options(url: string): MockRuleBuilder {
+    options(url: string, ctx?: MockRuleCtx): MockRuleBuilder {
         if (this.cors) {
             throw new Error(`Cannot mock OPTIONS requests with CORS enabled.
 
@@ -188,7 +188,7 @@ You can disable CORS by passing { cors: false } to getLocal/getRemote, but this 
 connecting to your mock server from browsers, unless you mock all required OPTIONS preflight \
 responses by hand.`);
         }
-        return new MockRuleBuilder(Method.OPTIONS, url, this.addRule);
+        return new MockRuleBuilder(Method.OPTIONS, url, this.addRule, ctx);
     }
 
 }

--- a/src/rules/mock-rule-builder.ts
+++ b/src/rules/mock-rule-builder.ts
@@ -5,7 +5,8 @@
 import { CompletedRequest, Method, MockedEndpoint } from "../types";
 
 import {
-    MockRuleData
+    MockRuleData,
+    MockRuleCtx
 } from "./mock-rule-types";
 
 import {
@@ -58,18 +59,20 @@ export default class MockRuleBuilder {
     constructor(
         method: Method,
         path: string,
-        addRule: (rule: MockRuleData) => Promise<MockedEndpoint>
+        addRule: (rule: MockRuleData) => Promise<MockedEndpoint>,
+        ctx?: MockRuleCtx
     )
     constructor(
         methodOrAddRule: Method | ((rule: MockRuleData) => Promise<MockedEndpoint>),
         path?: string,
-        addRule?: (rule: MockRuleData) => Promise<MockedEndpoint>
+        addRule?: (rule: MockRuleData) => Promise<MockedEndpoint>,
+        ctx?: MockRuleCtx,
     ) {
         if (methodOrAddRule instanceof Function) {
             this.matchers.push(new WildcardMatcherData());
             this.addRule = methodOrAddRule;
         } else {
-            this.matchers.push(new SimpleMatcherData(methodOrAddRule, path!));
+            this.matchers.push(new SimpleMatcherData(methodOrAddRule, path!, ctx));
             this.addRule = addRule!;
         }
     }

--- a/src/rules/mock-rule-types.ts
+++ b/src/rules/mock-rule-types.ts
@@ -17,6 +17,10 @@ export interface MockRule extends Explainable {
     requests: Promise<CompletedRequest>[];
 }
 
+export interface MockRuleCtx {
+    matchByPath?: boolean
+}
+
 export interface MockRuleData {
     matchers: MatcherData[];
     handler: HandlerData

--- a/test/integration/smoke-test.spec.ts
+++ b/test/integration/smoke-test.spec.ts
@@ -16,9 +16,17 @@ describe("Basic HTTP mocking", function () {
         expect(await response.text()).to.equal("mocked data");
     });
 
+    it("should mock simple matching request with query params", async () => {
+        await server.get("/v3/address/private/validate", { matchByPath: true }).thenReply(200, "mocked data");
+
+        let response = await fetch(server.urlFor("/v3/address/private/validate?address=jehagukoe@example.com"));
+
+        expect(await response.text()).to.equal("mocked data");
+    });
+
     nodeOnly(() => {
         it("should mock request via callback", async () => {
-            await server.get("/callback-endpoint").thenCallback(req => {
+            await server.get("/callback-endpoint").thenCallback(() => {
                 return {status: 200, body: "hello"};
             });
 


### PR DESCRIPTION
And add first option matchByPath. It's useful, when you have e.g. requests with query params and you want to mock them equally