### PR TITLE
Adding a forwarding option for pass through type rules.

### DIFF
--- a/src/rules/handlers.ts
+++ b/src/rules/handlers.ts
@@ -370,16 +370,24 @@ export class StreamHandlerData extends Serializable {
 export class PassThroughHandlerData extends Serializable {
     readonly type: 'passthrough' = 'passthrough';
 
+    constructor(private forwardToLocation?: string) {
+        super();
+    }
+
     buildHandler() {
         return _.assign(async (clientReq: OngoingRequest, clientRes: express.Response) => {
             const { method, originalUrl, headers } = clientReq;
             let { protocol, hostname, port, path } = url.parse(originalUrl);
+            if (this.forwardToLocation) {
+                ({ protocol, hostname, port } = url.parse(this.forwardToLocation));
+            }
 
             const socket: net.Socket = (<any> clientReq).socket;
             // If it's ipv4 masquerading as v6, strip back to ipv4
             const remoteAddress = socket.remoteAddress.replace(/^::ffff:/, '');
+            const remotePort = port ? Number.parseInt(port) : socket.remotePort;
 
-            if (isRequestLoop(remoteAddress, socket.remotePort)) {
+            if (isRequestLoop(remoteAddress, remotePort)) {
                 throw new Error(
 `Passthrough loop detected. This probably means you're sending a request directly to a passthrough endpoint, \
 which is forwarding it to the target URL, which is a passthrough endpoint, which is forwarding it to the target \

--- a/src/rules/handlers.ts
+++ b/src/rules/handlers.ts
@@ -457,7 +457,7 @@ instead of making requests to it directly`);
                     reject(e);
                 });
             });
-        }, { explain: () => 'pass the request through to the real server' });
+        }, { explain: () => this.forwardToLocation ? 'forward the request to the specified url' : 'pass the request through to the real server' });
     }
 }
 

--- a/src/rules/mock-rule-builder.ts
+++ b/src/rules/mock-rule-builder.ts
@@ -278,6 +278,9 @@ export default class MockRuleBuilder {
      * Pass matched requests through to their real destination. This works
      * for proxied requests only, direct requests will be rejected with
      * an error.
+     * 
+     * Specifying forwardToLocation will foward requests to that location
+     * instead of the address in the original url.
      *
      * Calling this method registers the rule with the server, so it
      * starts to handle requests.
@@ -287,11 +290,11 @@ export default class MockRuleBuilder {
      * before sending requests to be matched. The mocked endpoint
      * can be used to assert on the requests matched by this rule.
      */
-    thenPassThrough(): Promise<MockedEndpoint> {
+    thenPassThrough(forwardToLocation?: string): Promise<MockedEndpoint> {
         const rule: MockRuleData = {
             matchers: this.matchers,
             completionChecker: this.isComplete,
-            handler: new PassThroughHandlerData()
+            handler: new PassThroughHandlerData(forwardToLocation)
         };
 
         return this.addRule(rule);

--- a/src/rules/mock-rule-builder.ts
+++ b/src/rules/mock-rule-builder.ts
@@ -312,12 +312,12 @@ export default class MockRuleBuilder {
      * before sending requests to be matched. The mocked endpoint
      * can be used to assert on the requests matched by this rule.
      */
-    thenForwardTo(forwardToUrl: string): Promise<MockedEndpoint> {
+    async thenForwardTo(forwardToUrl: string): Promise<MockedEndpoint> {
         const { protocol, hostname, port, path } = url.parse(forwardToUrl);
         if (path && path.trim() !== "/") {
             const suggestion = url.format({ protocol, hostname, port });
-            throw new Error(`thenForwardTo location, "${forwardToUrl}", cannot include a path."
-                + " Did you mean ${suggestion}?`);
+            throw new Error(`URLs passed to thenForwardTo cannot include a path, but "${forwardToUrl}" does. \
+Did you mean ${suggestion}?`);
         }
 
         const rule: MockRuleData = {

--- a/src/rules/mock-rule-builder.ts
+++ b/src/rules/mock-rule-builder.ts
@@ -2,6 +2,8 @@
  * @module MockRule
  */
 
+import url = require("url");
+
 import { CompletedRequest, Method, MockedEndpoint } from "../types";
 
 import {
@@ -278,9 +280,6 @@ export default class MockRuleBuilder {
      * Pass matched requests through to their real destination. This works
      * for proxied requests only, direct requests will be rejected with
      * an error.
-     * 
-     * Specifying forwardToLocation will foward requests to that location
-     * instead of the address in the original url.
      *
      * Calling this method registers the rule with the server, so it
      * starts to handle requests.
@@ -290,11 +289,41 @@ export default class MockRuleBuilder {
      * before sending requests to be matched. The mocked endpoint
      * can be used to assert on the requests matched by this rule.
      */
-    thenPassThrough(forwardToLocation?: string): Promise<MockedEndpoint> {
+    thenPassThrough(): Promise<MockedEndpoint> {
         const rule: MockRuleData = {
             matchers: this.matchers,
             completionChecker: this.isComplete,
-            handler: new PassThroughHandlerData(forwardToLocation)
+            handler: new PassThroughHandlerData()
+        };
+
+        return this.addRule(rule);
+    }
+
+    /**
+     * Forward matched requests on to the specified forwardToUrl. The url
+     * specified must not include a path. Otherwise, an error is thrown.
+     * The path portion of the original request url is used instead.
+     *
+     * Calling this method registers the rule with the server, so it
+     * starts to handle requests.
+     *
+     * This method returns a promise that resolves with a mocked endpoint.
+     * Wait for the promise to confirm that the rule has taken effect
+     * before sending requests to be matched. The mocked endpoint
+     * can be used to assert on the requests matched by this rule.
+     */
+    thenForwardTo(forwardToUrl: string): Promise<MockedEndpoint> {
+        const { protocol, hostname, port, path } = url.parse(forwardToUrl);
+        if (path && path.trim() !== "/") {
+            const suggestion = url.format({ protocol, hostname, port });
+            throw new Error(`thenForwardTo location, "${forwardToUrl}", cannot include a path."
+                + " Did you mean ${suggestion}?`);
+        }
+
+        const rule: MockRuleData = {
+            matchers: this.matchers,
+            completionChecker: this.isComplete,
+            handler: new PassThroughHandlerData(forwardToUrl)
         };
 
         return this.addRule(rule);

--- a/test/integration/proxy.spec.ts
+++ b/test/integration/proxy.spec.ts
@@ -53,7 +53,7 @@ nodeOnly(() => {
             });
         });
 
-        describe.skip("with an HTTPS config", () => {
+        describe("with an HTTPS config", () => {
             beforeEach(async () => {
                 server = getLocal({
                     https: {


### PR DESCRIPTION
Hello Tim!

Here is a feature we found useful, when using mockttp in our tests. In short, it allows you to specify a location to forward requests when using the thenPassThrough() rule builder function. I think others might find it useful as well. Let me know what you think.

Thanks for mockttp!