### PR TITLE
docs: fix example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ describe("Mockttp", () => {
         .then(() => {
             // Make a request
             return superagent.get("http://localhost:8080/mocked-path");
-        }).then(() => {
+        }).then(response => {
             // Assert on the results
             expect(response.text).to.equal("A mocked response");
-        });
+        })
     );
 });
 ```


### PR DESCRIPTION
Nice library. I had trouble copy-pasting the example from README and having it run. A small typo fixed it, here it is. Note that removing the semicolon on line 69 is necessary.