### PR TITLE
Remove second `MockedEndpoint` interface

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,11 +7,7 @@ import MockttpClient from "./client/mockttp-client";
 import { MockttpStandalone, StandaloneServerOptions } from "./standalone/mockttp-standalone";
 
 import { Mockttp, MockttpOptions } from "./mockttp";
-export { OngoingRequest, CompletedRequest } from "./types";
-
-export interface MockedEndpoint {
-    getSeenRequests(): Request[]
-}
+export { OngoingRequest, CompletedRequest, MockedEndpoint } from "./types";
 
 export { Mockttp };
 


### PR DESCRIPTION
It looks like this is unused? I think it's breaking your exported interface. 

The following code didn't previously compile (and it looks like you intend for it to compile):

```ts
import * as mockttp from 'mockttp';

const mockServer = await mockttp.getLocal().start();
const mockedEndpoint: mockttp.MockedEndpoint = mockServer.get('/foo').thenReply(200);
```

```
error TS2719: Type 'MockedEndpoint' is not assignable to type 'MockedEndpoint'. Two different types with this name exist, but they are unrelated.
  Types of property 'getSeenRequests' are incompatible.
    Type '() => Promise<CompletedRequest[]>' is not assignable to type '() => Request[]'.
      Type 'Promise<CompletedRequest[]>' is not assignable to type 'Request[]'.
        Property 'includes' is missing in type 'Promise<CompletedRequest[]>'.
```